### PR TITLE
[HOT-59] AddIngredients component re-rendering on debounce function

### DIFF
--- a/client/src/pages/pot-instance/components/AddIngredients/AddIngredients.tsx
+++ b/client/src/pages/pot-instance/components/AddIngredients/AddIngredients.tsx
@@ -1,5 +1,5 @@
 import { Button, Drawer } from '@mui/material';
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import IngredientsList from 'pages/pot-instance/components/IngredientsList/IngredientsList';
 import { AddFoodTimer } from 'pages/pot-instance/models';
@@ -31,4 +31,4 @@ const AddIngredients = ({ addFoodTimer }: AddFoodTimer) => {
     </>
   );
 };
-export default AddIngredients;
+export default memo(AddIngredients);

--- a/client/src/pages/pot-instance/components/IngredientsList/IngredientsList.tsx
+++ b/client/src/pages/pot-instance/components/IngredientsList/IngredientsList.tsx
@@ -31,6 +31,10 @@ const IngredientsList: FC<Props> = ({ addFoodTimer, drawerOpen }) => {
   // Debounce the items selected in the cart before sending it to parent.
   const debouncedCart = useDebounce(ingredientsCart, 2000);
   useEffect(() => {
+    if (debouncedCart.length === 0) {
+      return;
+    }
+
     debouncedCart.forEach((ingredient) => {
       const startTime = Math.floor(Date.now() / 1000);
       const finishTime = startTime + ingredient.cookTime;


### PR DESCRIPTION
JIRA: https://hotpotbuddy.atlassian.net/browse/HOT-59

This PR pretty simple: memoize AddIngredients and don't trigger debounce function if cart is empty, which stops the opened Ingredients list component from re-rendering every time the debounce funcotin tirggers.