### PR TITLE
[HOTFIX] Address issues with memorized AddIngredients component.

### DIFF
--- a/client/src/pages/pot-instance/components/PotView/PotView.tsx
+++ b/client/src/pages/pot-instance/components/PotView/PotView.tsx
@@ -38,10 +38,10 @@ const PotView = ({ state, addToCookedPot }: Props) => {
         timeLeft: remainingTime
       };
       tempObj.push(addObj);
-      tempObj.sort((a, b) => a.currentTime - b.currentTime);
+      tempObj.sort((a, b) => a.timeLeft - b.timeLeft);
       setPotContent([...tempObj]);
     },
-    [setPotContent]
+    [potContent, setPotContent]
   );
 
   const handleTime = () => {


### PR DESCRIPTION
This PR address some issues with the memoized AddIngredients component temporary.
Since timeLeft is updating every second the addFoodTimer will cause the component to re-render, where ideally it doesn't need to. We will need to look separating the selected items and the timeLeft update. 